### PR TITLE
[task-69] add flavor tst for starting testactivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,17 @@ android {
         }
     }
 
+    flavorDimensions "startActivity"
 
+    productFlavors {
+        home {
+            dimension "startActivity"
+        }
+
+        tst {
+            dimension "startActivity"
+        }
+    }
 }
 
 dependencies {

--- a/app/src/home/AndroidManifest.xml
+++ b/app/src/home/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="ru.startandroid.organizer">
+
+    <application>
+        <activity android:name=".home.HomeActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,16 +11,6 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".fortest.TestActivity">
-        </activity>
-
-        <activity android:name=".home.HomeActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
 
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"

--- a/app/src/tst/AndroidManifest.xml
+++ b/app/src/tst/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="ru.startandroid.organizer">
+
+    <application>
+        <activity android:name=".fortest.TestActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>


### PR DESCRIPTION
I usually use TestActivity for testing new features while developing. I need to application start not from HomeActivity, but from TestActivity. I have to change manifest manually to do it. But it's possible to use flavors for it.

I created two flavors for starting different activities. It creates a new build variants.

![image](https://user-images.githubusercontent.com/5516236/61585099-3d909980-ab54-11e9-8792-1f15422c7b88.png)

Use homeDebug to start HomeActivity

Use tstDebug to start TestActivity. 